### PR TITLE
Add omarchy-walker wrapper script to replace direct walker calls

### DIFF
--- a/bin/omarchy-menu
+++ b/bin/omarchy-menu
@@ -33,7 +33,7 @@ menu() {
     fi
   fi
 
-  echo -e "$options" | walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
+  echo -e "$options" | omarchy-walker --dmenu --theme dmenu_250 -p "$prompt…" "${args[@]}"
 }
 
 terminal() {
@@ -463,7 +463,7 @@ show_main_menu() {
 
 go_to_menu() {
   case "${1,,}" in
-  *apps*) walker -p "Launch…" ;;
+  *apps*) omarchy-walker -p "Launch…" ;;
   *learn*) show_learn_menu ;;
   *trigger*) show_trigger_menu ;;
   *share*) show_share_menu ;;

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -89,5 +89,5 @@ menu_height=$((monitor_height * 40 / 100))
 dynamic_bindings | \
   sort -u | \
   parse_bindings | \
-  walker --dmenu --theme keybindings -p 'Keybindings' -w 800 -h "$menu_height"
+  omarchy-walker --dmenu --theme keybindings -p 'Keybindings' -w 800 -h "$menu_height"
 

--- a/bin/omarchy-walker
+++ b/bin/omarchy-walker
@@ -1,0 +1,2 @@
+killall -9 walker
+walker $@

--- a/default/hypr/bindings/utilities.conf
+++ b/default/hypr/bindings/utilities.conf
@@ -1,6 +1,6 @@
 # Menus
-bindd = SUPER, SPACE, Launch apps, exec, walker -p "Start…"
-bindd = SUPER CTRL, E, Emoji picker, exec, walker -m Emojis
+bindd = SUPER, SPACE, Launch apps, exec, omarchy-walker -p "Start…"
+bindd = SUPER CTRL, E, Emoji picker, exec, omarchy-walker -m Emojis
 bindd = SUPER ALT, SPACE, Omarchy menu, exec, omarchy-menu
 bindd = SUPER, ESCAPE, Power menu, exec, omarchy-menu system
 bindld = , XF86PowerOff, Power menu, exec, omarchy-menu system


### PR DESCRIPTION
> [!NOTE]
> This is a temporary fix until the walker 1.0-beta is integrated properly
> DO NOT MERGE

### Overview
This PR introduces a new omarchy-walker wrapper script that replaces direct `walker` calls throughout the system for better process management, predominantly preventing walker from hanging.

Temporarily Resolves basecamp/omarchy#952
Temporarily Resolves basecamp/omarchy#1871
Kind Of Temporarily Resolves basecamp/omarchy#698

### Key Changes

#### New omarchy-walker Wrapper
- Added omarchy-walker script that kills any existing walker processes before starting a new one
- Simple wrapper that runs `killall -9 walker` followed by `walker $@`
- Ensures clean walker restarts and prevents multiple instances

#### Updated Walker Integration  
- Replaced direct `walker` calls with omarchy-walker in Hyprland keybindings:
  - `SUPER + SPACE` for app launcher: `omarchy-walker -p "Start…"`
  - `SUPER + CTRL + E` for emoji picker: `omarchy-walker -m Emojis`
 
### Benefits
- Prevents walker process conflicts and memory leaks
- Ensures clean walker restarts across the system
- More reliable launcher behavior
- Consistent walker process management

### Testing
- Walker launches correctly with new wrapper script
- No multiple walker processes running simultaneously
- All keybindings work as expected
- No breaking changes to existing functionality